### PR TITLE
simplify code with template function

### DIFF
--- a/simdjson_ffi.cpp
+++ b/simdjson_ffi.cpp
@@ -96,7 +96,7 @@ extern "C" {
             return SIMDJSON_FFI_ERROR;
         }
 
-        return ++state->ops_n;
+        return state->ops_n;
     }
 
     int simdjson_ffi_next(simdjson_ffi_state *state, const char **errmsg) {


### PR DESCRIPTION
`simdjson_ffi_process_value()` has almost the same logic with `simdjson_ffi_parse()`, the only difference is the second parameter's type, so we could use C++ template function to reduce the duplicated code.

should rebase after https://github.com/dndx/lua-resty-simdjson/pull/3 is merged.