### PR TITLE
test: add cjson examples tests for compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         - openresty: "1.25.3.1"
 
     env:
-      JOBS: 2
+      JOBS: 1
 
       OPENRESTY: ${{ matrix.openresty }}
       CODE_PATH: ${{ github.workspace }}


### PR DESCRIPTION
The example4 of cjson is too large to add into `content_by_lua_block`, so I passed it.