### PR TITLE
chore(tests): remove the debug hook `collectgarbage()` call because it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,6 @@ jobs:
     - name: Run Valgrind
       run: |
         export PATH=${BASE_PATH}/openresty/bin:$PATH
-        export TEST_NGINX_INIT_BY_LUA="debug.sethook(function () collectgarbage() end, 'l') jit.off()"
         export TEST_NGINX_VALGRIND='--num-callers=100 -q --tool=memcheck --leak-check=full --show-possibly-lost=no --gen-suppressions=all --suppressions=valgrind.suppress --track-origins=yes' TEST_NGINX_TIMEOUT=60 TEST_NGINX_SLEEP=1
         export TEST_NGINX_USE_VALGRIND=1
         openresty -V


### PR DESCRIPTION
makes tests 2x slower (10m -> 20m).

https://github.com/Kong/lua-resty-simdjson/actions/runs/10065445403 <- with the debug hook
https://github.com/Kong/lua-resty-simdjson/actions/runs/10067217190 <- without the debug hook

We should still do `collectgarbage()`, but probably not every line, maybe after each test blocks?

Removing this for now so we could OSS the repo soon, but feel free to open another PR to do it another way.