### PR TITLE
refactor(src): shrink batch size to 1024

### DIFF
--- a/src/simdjson_ffi.h
+++ b/src/simdjson_ffi.h
@@ -6,7 +6,7 @@
 #include <limits>
 
 
-#define SIMDJSON_FFI_BATCH_SIZE 2048
+#define SIMDJSON_FFI_BATCH_SIZE 1024
 #define SIMDJSON_FFI_ERROR      -1
 
 


### PR DESCRIPTION
Currently `SIMDJSON_FFI_BATCH_SIZE` is `2048`, so a state object will be about `32KB`, it is a little expensive for small json string ( < 1KB) or encoding only, perhaps `1024` is a appropriate value.

In the future we could change the fixed size array to a dynamic `std::vector`, then allocate it on-demond. 
See #36

KAG-4938