### PR TITLE
refactor(src): using std::vector to allocate memory on-demond

### DIFF
--- a/lib/resty/simdjson/decoder.lua
+++ b/lib/resty/simdjson/decoder.lua
@@ -48,7 +48,7 @@ function _M.new(yieldable)
         ops_index = 0,
         ops_size = 0,
         state = ffi_gc(state, C.simdjson_ffi_state_free),
-        ops = C.simdjson_ffi_state_get_ops(state),
+        ops = nil,  -- reserved for decode
         yieldable = yieldable,
         decoding = false,
     }
@@ -209,6 +209,9 @@ function _M:process(json)
     if self.yieldable and self.decoding then
         error("decode is not reentrant", 2)
     end
+
+    -- allocate array memory on-demond
+    self.ops = assert(C.simdjson_ffi_state_get_ops(self.state))
 
     self.decoding = true
 

--- a/lib/resty/simdjson/decoder.lua
+++ b/lib/resty/simdjson/decoder.lua
@@ -202,7 +202,9 @@ end
 function _M:process(json)
     assert(type(json) == "string")
 
-    if not self.state then
+    local state = self.state
+
+    if not state then
         error("already destroyed", 2)
     end
 
@@ -211,11 +213,11 @@ function _M:process(json)
     end
 
     -- allocate array memory on-demond
-    self.ops = assert(C.simdjson_ffi_state_get_ops(self.state))
+    self.ops = assert(C.simdjson_ffi_state_get_ops(state))
 
     self.decoding = true
 
-    local res = C.simdjson_ffi_parse(self.state, json, #json, errmsg)
+    local res = C.simdjson_ffi_parse(state, json, #json, errmsg)
     if res == SIMDJSON_FFI_ERROR then
         self.decoding = false
         return nil, "simdjson: error: " .. ffi_string(errmsg[0])
@@ -231,7 +233,7 @@ function _M:process(json)
         return nil, err
     end
 
-    if res and res ~= ngx_null and C.simdjson_ffi_is_eof(self.state) ~= 1 then
+    if res and res ~= ngx_null and C.simdjson_ffi_is_eof(state) ~= 1 then
         return nil, "simdjson: error: trailing content found"
     end
 

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -160,12 +160,13 @@ extern "C"
 int simdjson_ffi_next(simdjson_ffi_state *state, const char **errmsg) try {
     SIMDJSON_DEVELOPMENT_ASSERT(state);
     SIMDJSON_DEVELOPMENT_ASSERT(errmsg);
+    SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() == SIMDJSON_FFI_BATCH_SIZE);
 
     state->ops_n = 0;
 
     while (!state->frames.empty()) {
 
-        if (state->ops_n >= SIMDJSON_FFI_BATCH_SIZE - 1) {
+        if (state->ops_n >= state->ops.size() - 1) {
             // -1 for key value pair which requires 2 ops
             return state->ops_n;
         }
@@ -192,7 +193,7 @@ int simdjson_ffi_next(simdjson_ffi_state *state, const char **errmsg) try {
                         break;
                     }
 
-                    if (state->ops_n >= SIMDJSON_FFI_BATCH_SIZE) {
+                    if (state->ops_n >= state->ops.size()) {
                         // array can use the last of the slots, no need to
                         // reserve two slots like object below
                         frame.processing = true;
@@ -234,7 +235,7 @@ int simdjson_ffi_next(simdjson_ffi_state *state, const char **errmsg) try {
                         break;
                     }
 
-                    if (state->ops_n >= SIMDJSON_FFI_BATCH_SIZE - 1) {
+                    if (state->ops_n >= state->ops.size() - 1) {
                         frame.processing = true;
 
                         return state->ops_n;

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -102,8 +102,9 @@ simdjson_ffi_state *simdjson_ffi_state_new() {
 extern "C"
 simdjson_ffi_op_t *simdjson_ffi_state_get_ops(simdjson_ffi_state *state) {
     SIMDJSON_DEVELOPMENT_ASSERT(state);
+    SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() == SIMDJSON_FFI_BATCH_SIZE);
 
-    return state->ops;
+    return state->ops.data();
 }
 
 

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -102,6 +102,9 @@ simdjson_ffi_state *simdjson_ffi_state_new() {
 extern "C"
 simdjson_ffi_op_t *simdjson_ffi_state_get_ops(simdjson_ffi_state *state) {
     SIMDJSON_DEVELOPMENT_ASSERT(state);
+
+    state->ops.resize(SIMDJSON_FFI_BATCH_SIZE);
+
     SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() == SIMDJSON_FFI_BATCH_SIZE);
 
     return state->ops.data();

--- a/src/simdjson_ffi.h
+++ b/src/simdjson_ffi.h
@@ -2,6 +2,7 @@
 #define SIMDJSON_FFI_H
 
 
+#include <vector>
 #include <stack>
 #include <limits>
 
@@ -93,7 +94,7 @@ struct simdjson_ffi_stack_frame {
 struct simdjson_ffi_state_t {
     simdjson::ondemand::parser            parser;
     simdjson::ondemand::document          document;
-    simdjson_ffi_op_t                     ops[SIMDJSON_FFI_BATCH_SIZE];
+    std::vector<simdjson_ffi_op_t>        ops{SIMDJSON_FFI_BATCH_SIZE};
     size_t                                ops_n;
     std::stack<simdjson_ffi_stack_frame>  frames;
     simdjson::padded_string               json;

--- a/src/simdjson_ffi.h
+++ b/src/simdjson_ffi.h
@@ -94,7 +94,7 @@ struct simdjson_ffi_stack_frame {
 struct simdjson_ffi_state_t {
     simdjson::ondemand::parser            parser;
     simdjson::ondemand::document          document;
-    std::vector<simdjson_ffi_op_t>        ops{SIMDJSON_FFI_BATCH_SIZE};
+    std::vector<simdjson_ffi_op_t>        ops;
     size_t                                ops_n;
     std::stack<simdjson_ffi_stack_frame>  frames;
     simdjson::padded_string               json;

--- a/src/simdjson_ffi.h
+++ b/src/simdjson_ffi.h
@@ -2,8 +2,8 @@
 #define SIMDJSON_FFI_H
 
 
-#include <vector>
 #include <stack>
+#include <vector>
 #include <limits>
 
 


### PR DESCRIPTION
With this PR the initial `sizeof(simdjson_ffi_state)` will be `232` bytes and not `32KB`.

KAG-4938