### PR TITLE
feat(lib): encode empty table to json object

### DIFF
--- a/lib/resty/simdjson/encoder.lua
+++ b/lib/resty/simdjson/encoder.lua
@@ -24,7 +24,7 @@ end
 
 local encode_helper
 do
-    local cjson = require("cjson.safe")
+    local cjson = assert(require("cjson"))
     local cjson_empty_array = cjson.empty_array
     local cjson_empty_array_mt = cjson.empty_array_mt
 

--- a/lib/resty/simdjson/encoder.lua
+++ b/lib/resty/simdjson/encoder.lua
@@ -24,6 +24,10 @@ end
 
 local encode_helper
 do
+    local cjson = require("cjson.safe")
+    local cjson_empty_array = cjson.empty_array
+    local cjson_empty_array_mt = cjson.empty_array_mt
+
     local pairs = pairs
     local tostring = tostring
     local string_byte = string.byte
@@ -182,6 +186,9 @@ do
 
         elseif item == ngx_null then
             cb("null", ctx)
+
+        elseif item == cjson_empty_array then
+            cb("[]", ctx)
 
         else
             return nil, "unsupported data type: " .. typ

--- a/lib/resty/simdjson/encoder.lua
+++ b/lib/resty/simdjson/encoder.lua
@@ -84,8 +84,14 @@ do
             return false
         end
 
-        local count = #tbl
         local nkeys = tb_nkeys(tbl)
+
+        -- empty table will be encoded to json object
+        if nkeys == 0 then
+            return false
+        end
+
+        local count = #tbl
 
         -- table is a normal array
         if count == nkeys then

--- a/lib/resty/simdjson/encoder.lua
+++ b/lib/resty/simdjson/encoder.lua
@@ -28,6 +28,7 @@ do
     local tostring = tostring
     local string_byte = string.byte
     local string_char = string.char
+    local tb_isempty = require("table.isempty")
     local tb_isarray = require("table.isarray")
     local tb_nkeys = require("table.nkeys")
 
@@ -79,19 +80,18 @@ do
     end
 
     local function table_isarray(tbl)
+        -- empty table will be encoded to json object
+        if tb_isempty(tbl) then
+            return false
+        end
+
         local is_array = tb_isarray(tbl)
         if not is_array then
             return false
         end
 
-        local nkeys = tb_nkeys(tbl)
-
-        -- empty table will be encoded to json object
-        if nkeys == 0 then
-            return false
-        end
-
         local count = #tbl
+        local nkeys = tb_nkeys(tbl)
 
         -- table is a normal array
         if count == nkeys then

--- a/lib/resty/simdjson/encoder.lua
+++ b/lib/resty/simdjson/encoder.lua
@@ -30,6 +30,7 @@ do
 
     local pairs = pairs
     local tostring = tostring
+    local getmetatable = getmetatable
     local string_byte = string.byte
     local string_char = string.char
     local tb_isempty = require("table.isempty")
@@ -85,7 +86,12 @@ do
 
     local function table_isarray(tbl)
         -- empty table will be encoded to json object
+        -- unless empty_array_mt is set
         if tb_isempty(tbl) then
+            if getmetatable(tbl) == cjson_empty_array_mt then
+                return true, 0
+            end
+
             return false
         end
 

--- a/t/03-encode.t
+++ b/t/03-encode.t
@@ -289,3 +289,31 @@ GET /t
 
 
 
+=== TEST 9: encode empty table to json object
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local simdjson = require("resty.simdjson")
+
+            local parser = simdjson.new()
+            assert(parser)
+
+            local v = parser:encode({})
+            assert(type(v) == "string")
+            assert(v == "{}")
+
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+

--- a/t/03-encode.t
+++ b/t/03-encode.t
@@ -289,31 +289,3 @@ GET /t
 
 
 
-=== TEST 9: encode empty table to json object
---- http_config eval: $::HttpConfig
---- config
-    location = /t {
-        content_by_lua_block {
-            local simdjson = require("resty.simdjson")
-
-            local parser = simdjson.new()
-            assert(parser)
-
-            local v = parser:encode({})
-            assert(type(v) == "string")
-            assert(v == "{}")
-
-            ngx.say("ok")
-        }
-    }
---- request
-GET /t
---- response_body
-ok
---- no_error_log
-[error]
-[warn]
-[crit]
-
-
-

--- a/t/09-empty_array.t
+++ b/t/09-empty_array.t
@@ -22,7 +22,7 @@ run_tests();
 __DATA__
 
 
-=== TEST 1: encode empty table to json object
+=== TEST 1: encode empty table as json object
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -35,6 +35,69 @@ __DATA__
             local v = parser:encode({})
             assert(type(v) == "string")
             assert(v == "{}")
+
+            local v = parser:encode({a = {}})
+            assert(type(v) == "string")
+            assert(v == [[{"a":{}}]])
+
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+
+=== TEST 2: cjson empty_array userdata
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local simdjson = require("resty.simdjson")
+
+            local parser = simdjson.new()
+            assert(parser)
+
+            local v = parser:encode({arr = cjson.empty_array})
+            assert(type(v) == "string")
+            assert(v == [[{"arr":[]}]])
+
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+
+=== TEST 3: cjson empty_array_mt
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local simdjson = require("resty.simdjson")
+
+            local parser = simdjson.new()
+            assert(parser)
+
+            local empty_arr = setmetatable({}, cjson.empty_array_mt)
+            local v = parser:encode({arr = empty_arr})
+            assert(type(v) == "string")
+            assert(v == [[{"arr":[]}]])
 
             ngx.say("ok")
         }

--- a/t/09-empty_array.t
+++ b/t/09-empty_array.t
@@ -1,0 +1,52 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * blocks() * 5;
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?/init.lua;$pwd/lib/?.lua;;";
+    lua_package_cpath "$pwd/?.so;;";
+};
+
+no_long_string();
+no_diff();
+
+run_tests();
+
+__DATA__
+
+
+=== TEST 1: encode empty table to json object
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local simdjson = require("resty.simdjson")
+
+            local parser = simdjson.new()
+            assert(parser)
+
+            local v = parser:encode({})
+            assert(type(v) == "string")
+            assert(v == "{}")
+
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+


### PR DESCRIPTION
Perhaps later we will add a new API [encode_empty_table_as_object](https://github.com/openresty/lua-cjson?tab=readme-ov-file#encode_empty_table_as_object).

KAG-5135