### PR TITLE
feat(lib): support `cjson.array_mt` when encoding

### DIFF
--- a/lib/resty/simdjson/encoder.lua
+++ b/lib/resty/simdjson/encoder.lua
@@ -89,7 +89,8 @@ do
         -- empty table will be encoded to json object
         -- unless empty_array_mt is set
         if tb_isempty(tbl) then
-            if getmetatable(tbl) == cjson_empty_array_mt then
+            local mt = getmetatable(tbl)
+            if mt == cjson_empty_array_mt or mt == cjson_array_mt then
                 return true, 0
             end
 

--- a/lib/resty/simdjson/encoder.lua
+++ b/lib/resty/simdjson/encoder.lua
@@ -114,7 +114,7 @@ do
 
         -- table may have negative/zero index or hole
 
-        local max = 1
+        local max = 0
         for k in pairs(tbl) do
             -- skip non-numeric keys
             if type(k) ~= "number" then

--- a/lib/resty/simdjson/encoder.lua
+++ b/lib/resty/simdjson/encoder.lua
@@ -25,6 +25,7 @@ end
 local encode_helper
 do
     local cjson = assert(require("cjson"))
+    local cjson_array_mt = cjson.array_mt
     local cjson_empty_array = cjson.empty_array
     local cjson_empty_array_mt = cjson.empty_array_mt
 
@@ -95,7 +96,9 @@ do
             return false
         end
 
-        local is_array = tb_isarray(tbl)
+        -- pure array or has cjson.array_mt
+        local is_array = tb_isarray(tbl) or
+                         getmetatable(tbl) == cjson_array_mt
         if not is_array then
             return false
         end
@@ -112,6 +115,11 @@ do
 
         local max = 1
         for k in pairs(tbl) do
+            -- skip non-numeric keys
+            if type(k) ~= "number" then
+                goto continue
+            end
+
             -- negative or zero index
             if k <= 0 then
                 return false
@@ -120,6 +128,8 @@ do
             if k > max then
                 max = k
             end
+
+            ::continue::
         end
 
         return true, max

--- a/t/10-array_mt.t
+++ b/t/10-array_mt.t
@@ -1,0 +1,155 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(1);
+
+plan tests => repeat_each() * blocks() * 5;
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?/init.lua;$pwd/lib/?.lua;;";
+    lua_package_cpath "$pwd/?.so;;";
+};
+
+no_long_string();
+no_diff();
+
+run_tests();
+
+__DATA__
+
+
+=== TEST 1: array_mt on empty tables
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local simdjson = require("resty.simdjson")
+
+            local parser = simdjson.new()
+            assert(parser)
+
+            local data = {}
+            setmetatable(data, cjson.array_mt)
+
+            local v = parser:encode(data)
+            assert(type(v) == "string")
+
+            ngx.say(v)
+        }
+    }
+--- request
+GET /t
+--- response_body
+[]
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+
+=== TEST 2: array_mt on non-empty tables
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local simdjson = require("resty.simdjson")
+
+            local parser = simdjson.new()
+            assert(parser)
+
+            local data = { "foo", "bar" }
+            setmetatable(data, cjson.array_mt)
+
+            local v = parser:encode(data)
+            assert(type(v) == "string")
+
+            ngx.say(v)
+        }
+    }
+--- request
+GET /t
+--- response_body
+["foo","bar"]
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+
+=== TEST 3: array_mt on non-empty tables with holes
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local simdjson = require("resty.simdjson")
+
+            local parser = simdjson.new()
+            assert(parser)
+
+            local data = {}
+            data[1] = "foo"
+            data[2] = "bar"
+            data[4] = "last"
+            data[9] = "none"
+            setmetatable(data, cjson.array_mt)
+
+            local v = parser:encode(data)
+            assert(type(v) == "string")
+
+            ngx.say(v)
+        }
+    }
+--- request
+GET /t
+--- response_body
+["foo","bar",null,"last"]
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+
+=== TEST 4: array_mt on tables with hash part
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local simdjson = require("resty.simdjson")
+
+            local parser = simdjson.new()
+            assert(parser)
+
+            local data = {}
+            data.foo = "bar"
+            data[1] = "hello"
+            data[3] = "world"
+            setmetatable(data, cjson.array_mt)
+
+            local v = parser:encode(data)
+            assert(type(v) == "string")
+
+            ngx.say(v)
+        }
+    }
+--- request
+GET /t
+--- response_body
+["hello",null,"world"]
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+

--- a/t/10-array_mt.t
+++ b/t/10-array_mt.t
@@ -3,7 +3,7 @@
 use Test::Nginx::Socket::Lua;
 use Cwd qw(cwd);
 
-repeat_each(1);
+repeat_each(2);
 
 plan tests => repeat_each() * blocks() * 5;
 
@@ -85,6 +85,7 @@ GET /t
 
 
 === TEST 3: array_mt on non-empty tables with holes
+--- ONLY
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {


### PR DESCRIPTION
See: https://github.com/openresty/lua-cjson?tab=readme-ov-file#array_mt

KAG-5172