### PR TITLE
refactor(src): use padded_string_view to save memory

### DIFF
--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -11,7 +11,7 @@ static long PAGESIZE = 0;
 
 static bool need_allocation(const char *buf, size_t len) {
     if (PAGESIZE == 0) {
-        PAGESIZE = sysconf(_SC_PAGESIZE);
+        PAGESIZE = getpagesize();
     }
 
     SIMDJSON_DEVELOPMENT_ASSERT(PAGESIZE > 0);

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -5,10 +5,18 @@
 using namespace simdjson;
 
 
-static bool need_allocation(const char *buf, size_t len) {
-    auto pagesize = sysconf(_SC_PAGESIZE);
+// we will initialize it only once
+static long PAGESIZE = 0;
 
-    return ((reinterpret_cast<uintptr_t>(buf + len - 1) % pagesize) <
+
+static bool need_allocation(const char *buf, size_t len) {
+    if (PAGESIZE == 0) {
+        PAGESIZE = sysconf(_SC_PAGESIZE);
+    }
+
+    SIMDJSON_DEVELOPMENT_ASSERT(PAGESIZE > 0);
+
+    return ((reinterpret_cast<uintptr_t>(buf + len - 1) % PAGESIZE) <
             SIMDJSON_PADDING);
 }
 

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -9,6 +9,12 @@ using namespace simdjson;
 static long PAGESIZE = 0;
 
 
+// An optimization from https://github.com/simdjson/simdjson/blob/master/doc/performance.md#free-padding
+// If ending of `buf` is at least `SIMDJSON_PADDING` away from the end of the current page,
+// then we technically don't need to copy the string and can safely let simdjson process
+// on the original buffer directly as `padded_string_view`.
+// This is because reading within the boundary of a mapped memory page is guaranteed
+// not to fail, even if these area might contain garbage data, simdjson will work correctly.
 static bool need_allocation(const char *buf, size_t len) {
     if (PAGESIZE == 0) {
         PAGESIZE = getpagesize();

--- a/src/simdjson_ffi.h
+++ b/src/simdjson_ffi.h
@@ -2,6 +2,7 @@
 #define SIMDJSON_FFI_H
 
 
+#include <unistd.h>
 #include <stack>
 #include <vector>
 #include <limits>


### PR DESCRIPTION
See: https://github.com/simdjson/simdjson/blob/master/doc/performance.md#free-padding

KAG-5178