### PR TITLE
refactor(src): allocate memory according to json string length

### DIFF
--- a/lib/resty/simdjson/cdefs.lua
+++ b/lib/resty/simdjson/cdefs.lua
@@ -71,7 +71,7 @@ typedef struct {
 typedef struct simdjson_ffi_state_t simdjson_ffi_state;
 
 simdjson_ffi_state *simdjson_ffi_state_new();
-simdjson_ffi_op_t *simdjson_ffi_state_get_ops(simdjson_ffi_state *state);
+simdjson_ffi_op_t *simdjson_ffi_state_get_ops(simdjson_ffi_state *state, size_t json_len);
 void simdjson_ffi_state_free(simdjson_ffi_state *state);
 int simdjson_ffi_is_eof(simdjson_ffi_state *state);
 int simdjson_ffi_parse(simdjson_ffi_state *state, const char *json, size_t len, char **errmsg);

--- a/lib/resty/simdjson/decoder.lua
+++ b/lib/resty/simdjson/decoder.lua
@@ -221,7 +221,8 @@ function _M:process(json)
     local json_len = #json
 
     -- allocate array memory on-demond
-    self.ops = assert(C.simdjson_ffi_state_get_ops(state, json_len))
+    self.ops = assert(C.simdjson_ffi_state_get_ops(
+                        state, self.yieldable and json_len or 0))
 
     self.decoding = true
 

--- a/lib/resty/simdjson/decoder.lua
+++ b/lib/resty/simdjson/decoder.lua
@@ -218,12 +218,14 @@ function _M:process(json)
         error("decode is not reentrant", 2)
     end
 
+    local json_len = #json
+
     -- allocate array memory on-demond
-    self.ops = assert(C.simdjson_ffi_state_get_ops(state))
+    self.ops = assert(C.simdjson_ffi_state_get_ops(state, json_len))
 
     self.decoding = true
 
-    local res = C.simdjson_ffi_parse(state, json, #json, errmsg)
+    local res = C.simdjson_ffi_parse(state, json, json_len, errmsg)
     if res == SIMDJSON_FFI_ERROR then
         self.decoding = false
         return nil, "simdjson: error: " .. ffi_string(errmsg[0])

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -150,7 +150,7 @@ simdjson_ffi_op_t *simdjson_ffi_state_get_ops(simdjson_ffi_state *state, size_t 
 
     state->ops.resize(batch_size);
 
-    //SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() == SIMDJSON_FFI_BATCH_SIZE);
+    SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() <= SIMDJSON_FFI_BATCH_SIZE);
 
     return state->ops.data();
 }
@@ -207,7 +207,7 @@ extern "C"
 int simdjson_ffi_next(simdjson_ffi_state *state, const char **errmsg) try {
     SIMDJSON_DEVELOPMENT_ASSERT(state);
     SIMDJSON_DEVELOPMENT_ASSERT(errmsg);
-    //SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() == SIMDJSON_FFI_BATCH_SIZE);
+    SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() <= SIMDJSON_FFI_BATCH_SIZE);
 
     state->ops_n = 0;
 

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -135,7 +135,7 @@ simdjson_ffi_state *simdjson_ffi_state_new() {
 }
 
 
-// We try to minimize the memory usage for short json string,
+// We try to minimize the memory usage for small json,
 // if the length of string is less than 4KB,
 // we will allocate one smaller memory.
 extern "C"

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -142,11 +142,12 @@ extern "C"
 simdjson_ffi_op_t *simdjson_ffi_state_get_ops(simdjson_ffi_state *state, size_t json_len) {
     SIMDJSON_DEVELOPMENT_ASSERT(state);
 
-    size_t batch_size = (json_len <= 1024) ?
+    size_t batch_size = (json_len == 0) ? SIMDJSON_FFI_BATCH_SIZE :
+                        (json_len <= 1024) ?
                             SIMDJSON_FFI_BATCH_SIZE / 4 :
-                            (json_len <= 4 * 1024 ?
-                                 SIMDJSON_FFI_BATCH_SIZE / 2 :
-                                 SIMDJSON_FFI_BATCH_SIZE);
+                        (json_len <= 4 * 1024 ?
+                            SIMDJSON_FFI_BATCH_SIZE / 2 :
+                            SIMDJSON_FFI_BATCH_SIZE);
 
     state->ops.resize(batch_size);
 

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -143,11 +143,11 @@ simdjson_ffi_op_t *simdjson_ffi_state_get_ops(simdjson_ffi_state *state, size_t 
     SIMDJSON_DEVELOPMENT_ASSERT(state);
 
     size_t batch_size = (json_len == 0) ? SIMDJSON_FFI_BATCH_SIZE :
-                        (json_len <= 1024) ?
+                        (json_len <= 1024 ?
                             SIMDJSON_FFI_BATCH_SIZE / 4 :
                         (json_len <= 4 * 1024 ?
                             SIMDJSON_FFI_BATCH_SIZE / 2 :
-                            SIMDJSON_FFI_BATCH_SIZE);
+                            SIMDJSON_FFI_BATCH_SIZE));
 
     state->ops.resize(batch_size);
 

--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -5,7 +5,7 @@
 using namespace simdjson;
 
 
-// we will initialize it only once
+// We will initialize it only once
 static long PAGESIZE = 0;
 
 
@@ -135,13 +135,22 @@ simdjson_ffi_state *simdjson_ffi_state_new() {
 }
 
 
+// We try to minimize the memory usage for short json string,
+// if the length of string is less than 4KB,
+// we will allocate one smaller memory.
 extern "C"
-simdjson_ffi_op_t *simdjson_ffi_state_get_ops(simdjson_ffi_state *state) {
+simdjson_ffi_op_t *simdjson_ffi_state_get_ops(simdjson_ffi_state *state, size_t json_len) {
     SIMDJSON_DEVELOPMENT_ASSERT(state);
 
-    state->ops.resize(SIMDJSON_FFI_BATCH_SIZE);
+    size_t batch_size = (json_len <= 1024) ?
+                            SIMDJSON_FFI_BATCH_SIZE / 4 :
+                            (json_len <= 4 * 1024 ?
+                                 SIMDJSON_FFI_BATCH_SIZE / 2 :
+                                 SIMDJSON_FFI_BATCH_SIZE);
 
-    SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() == SIMDJSON_FFI_BATCH_SIZE);
+    state->ops.resize(batch_size);
+
+    //SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() == SIMDJSON_FFI_BATCH_SIZE);
 
     return state->ops.data();
 }
@@ -198,7 +207,7 @@ extern "C"
 int simdjson_ffi_next(simdjson_ffi_state *state, const char **errmsg) try {
     SIMDJSON_DEVELOPMENT_ASSERT(state);
     SIMDJSON_DEVELOPMENT_ASSERT(errmsg);
-    SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() == SIMDJSON_FFI_BATCH_SIZE);
+    //SIMDJSON_DEVELOPMENT_ASSERT(state->ops.size() == SIMDJSON_FFI_BATCH_SIZE);
 
     state->ops_n = 0;
 


### PR DESCRIPTION
KAG-5179

If we set `yieldable` to `false`, the library should have only one instance, using a fixed size memory, memory is not a concern.
If we set `yieldable` to `true`, we may create many instances, then we should  allocate memory according to json string length to save memory. 