### PR TITLE
Fix `PAGESIZE` to compile on systems where it's already defined as a macro.

### DIFF
--- a/src/simdjson_ffi.cpp
+++ b/src/simdjson_ffi.cpp
@@ -4,9 +4,10 @@
 
 using namespace simdjson;
 
-
+#ifndef PAGESIZE // This is defined as a macro on some systms.
 // we will initialize it only once
 static long PAGESIZE = 0;
+#endif
 
 
 // An optimization from https://github.com/simdjson/simdjson/blob/master/doc/performance.md#free-padding
@@ -16,9 +17,11 @@ static long PAGESIZE = 0;
 // This is because reading within the boundary of a mapped memory page is guaranteed
 // not to fail, even if these area might contain garbage data, simdjson will work correctly.
 static bool need_allocation(const char *buf, size_t len) {
+#ifndef PAGESIZE
     if (PAGESIZE == 0) {
         PAGESIZE = getpagesize();
     }
+#endif
 
     SIMDJSON_DEVELOPMENT_ASSERT(PAGESIZE > 0);
 


### PR DESCRIPTION
On some systems `PAGESIZE` is a macro that expands to a numeric constant.  This causes a syntax error.

```c
/tmp/lua-resty-simdjson-1.2.0 # make libsimdjson_ffi.o
c++ -ggdb -O3 -DNDEBUG -o libsimdjson_ffi.o  -c -fPIC src/simdjson_ffi.cpp
In file included from /usr/include/limits.h:40,
                 from /usr/include/c++/13.2.1/climits:42,
                 from src/simdjson.h:136,
                 from src/simdjson_ffi.cpp:1:
src/simdjson_ffi.cpp:9:13: error: expected unqualified-id before numeric constant
    9 | static long PAGESIZE = 0;
      |             ^~~~~~~~
src/simdjson_ffi.cpp: In function 'bool need_allocation(const char*, std::size_t)':
src/simdjson_ffi.cpp:20:9: error: lvalue required as left operand of assignment
   20 |         PAGESIZE = getpagesize();
      |         ^~~~~~~~
make: *** [Makefile:40: libsimdjson_ffi.o] Error 1
```

This PR fixes this by using `ifndef` to only try to initialize and set it if the macro doesn't exist.